### PR TITLE
simplified label drop and typo fix

### DIFF
--- a/just-pandas-things.ipynb
+++ b/just-pandas-things.ipynb
@@ -407,7 +407,7 @@
     "\n",
     "Get row -> get review is 25x slower than get review -> get row.\n",
     "\n",
-    "**Note**: You can also just use `df.loc[0, \"Review\"]` to calculate the memory address to retrieve the item. Its performance is comparable to gret row then get review."
+    "**Note**: You can also just use `df.loc[0, \"Review\"]` to calculate the memory address to retrieve the item. Its performance is comparable to get review then get row."
    ]
   },
   {
@@ -2323,9 +2323,8 @@
     }
    ],
    "source": [
-    "# To drop a label, you need to first convert the labels to a column, then remove that column\n",
-    "df.reset_index(inplace=True)\n",
-    "df.drop(columns=\"Type\", inplace=True)\n",
+    "# To drop a label, you need to use reset_index with drop=True\n",
+    "df.reset_index(drop=True, inplace=True)\n",
     "df"
    ]
   },


### PR DESCRIPTION
1. typo in get review/get row
2. drop label oneliner