### PR TITLE
fix typos

### DIFF
--- a/just-pandas-things.ipynb
+++ b/just-pandas-things.ipynb
@@ -1546,7 +1546,7 @@
     "Currently, our `DataFrame` has no labels yet. To create labels, use `.set_index()`.\n",
     "\n",
     "1. Labels can be integers or strings\n",
-    "2. A DatamFrame can have multiple labels"
+    "2. A DataFrame can have multiple labels"
    ]
   },
   {
@@ -2576,7 +2576,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to sanity check if `Process` corresponds to `Review`, but `Review` is cut off in the display above. To show longer columns, you can set `display.max_colwidth` to `100`.\n",
+    "We want to sanity check if `Process` corresponds to `Review`, but `Review` is cut off in the display above. To show wider columns, you can set `display.max_colwidth` to `100`.\n",
     "\n",
     "**Note**: set_option has several great options you should check out."
    ]


### PR DESCRIPTION
1. "DatamFrame" --> "DataFrame"
2. "longer" --> "wider" columns. I think in this context, you want to make columns wider to read. So I changed it to "wider".